### PR TITLE
Add new variable to the context structure: extpipecmdline

### DIFF
--- a/event.c
+++ b/event.c
@@ -830,13 +830,14 @@ static void event_create_extpipe(struct context *cnt,
             return ;
 
         mystrftime(cnt, stamp, sizeof(stamp), cnt->conf.movie_extpipe, currenttime_tv, cnt->extpipefilename, 0);
+        snprintf(cnt->extpipecmdline, PATH_MAX - 1, "%s", stamp);
 
-        MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, _("pipe: %s"), stamp);
+        MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, _("pipe: %s"), cnt->extpipecmdline);
 
         MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "cnt->moviefps: %d", cnt->movie_fps);
 
         event(cnt, EVENT_FILECREATE, NULL, cnt->extpipefilename, (void *)FTYPE_MPEG, currenttime_tv);
-        cnt->extpipe = popen(stamp, "we");
+        cnt->extpipe = popen(cnt->extpipecmdline, "we");
 
         if (cnt->extpipe == NULL) {
             MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, _("popen failed"));
@@ -872,7 +873,7 @@ static void event_extpipe_put(struct context *cnt,
            }
         } else {
             MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO
-                ,_("pipe %s not created or closed already "), cnt->conf.movie_extpipe);
+                ,_("pipe %s not created or closed already "), cnt->extpipecmdline);
         }
     }
 }

--- a/motion.h
+++ b/motion.h
@@ -471,6 +471,7 @@ struct context {
     int movie_fps;
     char newfilename[PATH_MAX];
     char extpipefilename[PATH_MAX];
+    char extpipecmdline[PATH_MAX];
     int movie_last_shot;
 
     struct ffmpeg   *ffmpeg_output;


### PR DESCRIPTION
It will contain full command line of extpipe
The problem was that this command line was only stored in a temp buffer
upon creation of the pipe. So it was not possible to write full command
line into log if pipe fails to put a frame