### PR TITLE
Fix for merge error in alg.c

### DIFF
--- a/src/alg.c
+++ b/src/alg.c
@@ -2655,7 +2655,7 @@ void alg_update_reference_frame(struct context *cnt, int action)
 
     } else {   /* action == RESET_REF_FRAME - also used to initialize the frame at startup. */
         /* Copy fresh image */
-        memcpy(cnt->imgs.ref, cnt->imgs.image_virgin.image_norm, cnt->imgs.size_norm);
+        memcpy(cnt->imgs.ref, cnt->imgs.image_vprvcy.image_norm, cnt->imgs.size_norm);
         /* Reset static objects */
         memset(cnt->imgs.ref_dyn, 0, cnt->imgs.motionsize * sizeof(*cnt->imgs.ref_dyn));
     }
@@ -2670,7 +2670,7 @@ void alg_update_reference_frame(struct context *cnt, int action)
     int accept_timer = cnt->lastrate * ACCEPT_STATIC_OBJECT_TIME;
     int i, threshold_ref;
     int *ref_dyn = cnt->imgs.ref_dyn;
-    unsigned char *image_virgin = cnt->imgs.image_virgin.image_norm;
+    unsigned char *image_virgin = cnt->imgs.image_vprvcy.image_norm;
     unsigned char *ref = cnt->imgs.ref;
     unsigned char *smartmask = cnt->imgs.smartmask_final;
     unsigned char *out = cnt->imgs.img_motion.image_norm;


### PR DESCRIPTION
Fix for merge quirk from merge with motion/motion (https://github.com/Motion-Project/motion/pull/846).
tosiare/motion, alg.c contains duplicate implementations for some functions.
Changed lines from motion/motion will only be merged to 1 implementation in tosiara/motion.
Spotted  while (finally) working on NEON_2_SSE stuff.