### PR TITLE
Poor man thread sync, more granular sleep to reduce the delay

### DIFF
--- a/src/webu_stream.c
+++ b/src/webu_stream.c
@@ -226,6 +226,7 @@ static void webu_stream_static_getimg(struct webui_ctx *webui)
     memset(webui->resp_page, '\0', webui->resp_size);
 
     pthread_mutex_lock(&webui->cnt->mutex_stream);
+
         /* If no image, sleep up to 2 seconds (20 * 0.1) and then fail */
         for (int i = 0; i < 20; i++) {
             if (webui->cnt->stream_norm.jpeg_data != NULL) {


### PR DESCRIPTION
Original issue: https://github.com/Motion-Project/motion/issues/1588
Mitigation PR: https://github.com/Motion-Project/motion/commit/65963d75facce2ff64a5832f8753b78883094587

Testing showed that the delay sometimes may reach 300 ms, but on average it is under 100 ms. Which is a great improvement compared to the original mitigation (1 sec and then fail).
```
[0:st0] [ERR] [STR] [Feb 10 16:18:59] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 1
[0:st0] [ERR] [STR] [Feb 11 12:34:55] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 1
[0:st0] [ERR] [STR] [Feb 11 18:36:47] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 1
[0:st0] [ERR] [STR] [Feb 12 15:24:36] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 1
[0:st0] [ERR] [STR] [Feb 14 18:47:24] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 1
[0:st0] [ERR] [STR] [Feb 14 18:47:24] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 2
[0:st0] [ERR] [STR] [Feb 14 18:47:24] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 3
[0:st0] [ERR] [STR] [Feb 16 17:45:04] webu_stream_static_getimg: TODO: find a better way to sync threads, SLEEP 100 ms, try 1

```