### PR TITLE
Fixed file:// infinite loop due to rtsp restart

### DIFF
--- a/src/netcam_rtsp.c
+++ b/src/netcam_rtsp.c
@@ -464,6 +464,11 @@ static int netcam_rtsp_decode_video(struct rtsp_context *rtsp_data)
             av_strerror(retcd, errstr, sizeof(errstr));
             MOTION_LOG(INF, TYPE_NETCAM, NO_ERRNO
                 ,_("Error sending packet to codec: %s"), errstr);
+            if (!strcmp(rtsp_data->service, "file"))
+            {
+                MOTION_LOG(INF, TYPE_NETCAM, NO_ERRNO, _("Ignoring the above error for file://"));
+                return 0;
+            }
             return -1;
         }
 


### PR DESCRIPTION
Errors in file may cause motion to restart the file from start:
```
[2:nc2:motion] [INF] [NET] netcam_rtsp_decode_video: Ignoring packet with invalid data
[2:nc2:motion] [INF] [ENC] ffmpeg_avcodec_log: out of range intra chroma pred mode
[2:nc2:motion] [INF] [ENC] ffmpeg_avcodec_log: error while decoding MB 23 34
[2:nc2:motion] [INF] [NET] netcam_rtsp_decode_video: Ignoring packet with invalid data
[2:nc2:motion] [INF] [ENC] ffmpeg_avcodec_log: Missing reference picture, default is 0
[2:nc2:motion] [INF] [ENC] ffmpeg_avcodec_log: decode_slice_header error
[2:nc2:motion] [INF] [NET] netcam_rtsp_decode_video: Error sending packet to codec: Invalid argument
[2:nc2:motion] [ERR] [NET] netcam_rtsp_handler_reconnect: norm: Reconnecting with camera....
[2:nc2:motion] [INF] [NET] netcam_rtsp_set_options: norm: Setting up movie file
```
Reported also upstream: https://github.com/Motion-Project/motion/issues/1651